### PR TITLE
fix: pass baseURL to providers, set maxTokens default, add Parallel.ai fallback

### DIFF
--- a/src/cli/renderer.ts
+++ b/src/cli/renderer.ts
@@ -666,7 +666,7 @@ export class StreamRenderer {
         break;
       }
 
-      case "tavily_search_results_json": {
+      case "web_search": {
         const query = String(args.query ?? "");
         const short = query.length > 50 ? query.slice(0, 47) + "..." : query;
         if (this.toolSpinner) {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -7,6 +7,7 @@ const DEFAULT_MODEL_CONFIG: ModelConfig = {
   modelName: "minimax-m2.5:cloud",
   temperature: 0,
   maxRetries: 3,
+  maxTokens: 4096,
   baseUrl: "http://localhost:11434",
 };
 

--- a/src/llms/provider.ts
+++ b/src/llms/provider.ts
@@ -23,16 +23,19 @@ export async function createModel(config: ModelConfig): Promise<BaseChatModel> {
         temperature: config.temperature ?? 0,
         maxRetries: config.maxRetries ?? 3,
         apiKey: config.apiKey ?? process.env["OPENAI_API_KEY"],
+        configuration: {
+          baseURL: config.baseUrl ?? process.env["OPENAI_BASE_URL"],
+        },
       });
     }
-    
 
-   case "openrouter":{
+   case "openrouter": {
     return new ChatOpenRouter({
       model: config.modelName,
       temperature: config.temperature ?? 0,
       maxRetries: config.maxRetries ?? 3,
       apiKey: config.apiKey ?? process.env["OPENROUTER_API_KEY"],
+      baseURL: config.baseUrl ?? process.env["OPENROUTER_BASE_URL"],
     });
    }
 

--- a/src/llms/provider.ts
+++ b/src/llms/provider.ts
@@ -3,7 +3,6 @@ import type { BaseChatModel } from "@langchain/core/language_models/chat_models"
 import type { ModelConfig } from "../types/index.js";
 import { ChatOpenRouter } from "@langchain/openrouter";
 
-
 export async function createModel(config: ModelConfig): Promise<BaseChatModel> {
   const provider = config.provider.toLowerCase();
 
@@ -22,6 +21,7 @@ export async function createModel(config: ModelConfig): Promise<BaseChatModel> {
         model: config.modelName,
         temperature: config.temperature ?? 0,
         maxRetries: config.maxRetries ?? 3,
+        maxTokens: config.maxTokens ?? 4096,
         apiKey: config.apiKey ?? process.env["OPENAI_API_KEY"],
         configuration: {
           baseURL: config.baseUrl ?? process.env["OPENAI_BASE_URL"],
@@ -34,6 +34,7 @@ export async function createModel(config: ModelConfig): Promise<BaseChatModel> {
       model: config.modelName,
       temperature: config.temperature ?? 0,
       maxRetries: config.maxRetries ?? 3,
+      maxTokens: config.maxTokens ?? 4096,
       apiKey: config.apiKey ?? process.env["OPENROUTER_API_KEY"],
       baseURL: config.baseUrl ?? process.env["OPENROUTER_BASE_URL"],
     });

--- a/src/tools/web-search.ts
+++ b/src/tools/web-search.ts
@@ -1,7 +1,105 @@
 import { TavilySearch } from "@langchain/tavily";
+import { tool } from "@langchain/core/tools";
+import { z } from "zod";
 
-export function createWebSearchTool(maxResults = 3) {
-  return new TavilySearch({
-    maxResults,
-  });
+const PARALLEL_URL = "https://search.parallel.ai/mcp";
+const PARALLEL_TIMEOUT_MS = 25_000;
+
+async function callParallelSearch(query: string): Promise<string> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), PARALLEL_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(PARALLEL_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+        "User-Agent": "sajicode/1.2.3",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: {
+          name: "web_search",
+          arguments: {
+            objective: query,
+            search_queries: [query],
+          },
+        },
+      }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      throw new Error(`Parallel.ai returned HTTP ${response.status}`);
+    }
+
+    const body = await response.text();
+    const trimmed = body.trim();
+
+    if (trimmed.startsWith("{")) {
+      const text = parseMcpText(trimmed);
+      if (text) return text;
+    }
+
+    for (const line of body.split("\n")) {
+      if (!line.startsWith("data: ")) continue;
+      const payload = line.substring(6).trim();
+      if (!payload.startsWith("{")) continue;
+      const text = parseMcpText(payload);
+      if (text) return text;
+    }
+
+    return "No search results found.";
+  } catch (error: unknown) {
+    if (error instanceof Error && error.name === "AbortError") {
+      throw new Error("Parallel.ai search request timed out");
+    }
+    throw error;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function parseMcpText(json: string): string | undefined {
+  try {
+    const parsed = JSON.parse(json);
+    const content = parsed?.result?.content;
+    if (Array.isArray(content)) {
+      for (const item of content) {
+        if (item?.text) return item.text;
+      }
+    }
+  } catch {
+    // skip
+  }
+  return undefined;
+}
+
+export function createWebSearchTool(tavilyApiKey?: string, maxResults = 3) {
+  const apiKey = tavilyApiKey ?? process.env["TAVILY_API_KEY"];
+
+  if (apiKey) {
+    return new TavilySearch({
+      maxResults,
+      tavilyApiKey: apiKey,
+      name: "web_search",
+    });
+  }
+
+  return tool(
+    async ({ query }: { query: string }): Promise<string> => {
+      return callParallelSearch(query);
+    },
+    {
+      name: "web_search",
+      description:
+        "Search the web for information on current events, documentation, code examples, and more.",
+      schema: z.object({
+        query: z.string().describe("The search query"),
+      }),
+    },
+  );
 }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -3,6 +3,7 @@ export interface ModelConfig {
   modelName: string;
   temperature?: number;
   maxRetries?: number;
+  maxTokens?: number;
   baseUrl?: string;
   apiKey?: string;
 }


### PR DESCRIPTION
Three fixes for SajiCode:

1. **Base URL not forwarded** to OpenAI and OpenRouter providers. Setting a custom `baseUrl` in the config had no effect -- requests always hit the default URL.
2. **maxTokens was never sent** to the provider. Reasoning models like deepseek-v4-flash returned empty content without an explicit cap.
3. **Web search crashed on startup** when `TAVILY_API_KEY` was not set. Replaced with a dual-backend: TavilySearch when the key is present, free Parallel.ai fallback otherwise.

Fixes #13

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Web search functionality now supports Parallel.ai as an alternative provider option.

* **Configuration & Improvements**
  * Model configuration now includes configurable maximum token limits (defaults to 4096 tokens).
  * LLM providers now support custom API endpoints and token limit settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->